### PR TITLE
Adds support for SWNE decimal coordinates

### DIFF
--- a/src/openMapInWebview.ts
+++ b/src/openMapInWebview.ts
@@ -35,8 +35,9 @@ export async function openMapInWebview(selectedText: string, context: vscode.Ext
  * @returns An array of [lat, lng] pairs.
  */
 export function convertStrToMarkers(str: string): string[][] {
+    const cleanedUpStr = str.trim().replace(/S|W/g, '-').replace(/N|E/g, '');
     const regex = /(\-?\d+(\.\d+)?\s*,\s*\-?\d+(\.\d+)?)/g;
-    const pairs = str.match(regex);
+    const pairs = cleanedUpStr.match(regex);
 
     return (pairs ?? []).map(latlng => latlng.split(',').map(num => num.trim()));
 }


### PR DESCRIPTION
I have a use case where this extension is very useful, unfortunately it doesn't work off the bat as the coordinates used in my project contain S, N, W or E in the beginning of a decimal lat/long.

Here's an example: https://github.com/Eitz/endless-atc-airports/blob/main/SBFL.txt

I've made a small change to support this format as well.

Please note that it seems that your code only supports the decimal format, so I am not sure if the changes I made are going to potentially break any other format.

I am already using these changes locally but it made sense to open a PR to share it with the repo.